### PR TITLE
Keyframe Controls

### DIFF
--- a/XLPrecisionKeyframes/Patches/ReplayStatePatch.cs
+++ b/XLPrecisionKeyframes/Patches/ReplayStatePatch.cs
@@ -38,10 +38,12 @@ namespace XLPrecisionKeyframes.Patches
             /// </summary>
             static void Postfix()
             {
-                var camTransform = ReplayEditorController.Instance?.cameraController?.ReplayCamera?.transform;
+                var cameraController = ReplayEditorController.Instance?.cameraController;
+                var camTransform = cameraController?.ReplayCamera?.transform;
                 var time = ReplayEditorController.Instance?.playbackController?.CurrentTime;
 
                 UserInterface.Instance.UpdateTextFields(camTransform, time);
+                UserInterface.Instance.UpdateKeyFrameControls(cameraController?.keyFrames, time);
             }
         }
     }

--- a/XLPrecisionKeyframes/UserInterface.cs
+++ b/XLPrecisionKeyframes/UserInterface.cs
@@ -21,6 +21,8 @@ namespace XLPrecisionKeyframes
         /// </summary>
         private static List<KeyFrame> keyFrames = new List<KeyFrame>();
 
+        private static string currentKeyframeName = "";
+
         private void OnEnable()
         {
             Cursor.visible = true;
@@ -68,11 +70,16 @@ namespace XLPrecisionKeyframes
             if (!keyFrames.Any()) return;
 
             GUILayout.BeginVertical();
-            GUILayout.Label("Keyframe Name", new GUIStyle(GUI.skin.textField)
+
+            if (!string.IsNullOrEmpty(currentKeyframeName))
             {
-                alignment = TextAnchor.MiddleCenter,
-                fontStyle = FontStyle.Bold
-            });
+                GUILayout.Label(currentKeyframeName, new GUIStyle(GUI.skin.label)
+                {
+                    alignment = TextAnchor.MiddleCenter,
+                    fontStyle = FontStyle.Bold
+                });
+            }
+            
             GUILayout.BeginHorizontal();
 
             if (GUILayout.Button("<<"))
@@ -88,7 +95,7 @@ namespace XLPrecisionKeyframes
 
             if (GUILayout.Button(">"))
             {
-                ReplayEditorController.Instance.JumpByTime(-ReplaySettings.Instance.PlaybackTimeJumpDelta, true);
+                ReplayEditorController.Instance.JumpByTime(ReplaySettings.Instance.PlaybackTimeJumpDelta, true);
             }
 
             if (GUILayout.Button(">>"))
@@ -159,19 +166,12 @@ namespace XLPrecisionKeyframes
             GUILayout.EndHorizontal();
         }
 
-        private float ParseStringToFloat(string value)
-        {
-            if (!float.TryParse(value, out float parsedFloat))
-            {
-                return 0;
-            }
-
-            return parsedFloat;
-        }
-
-        public void UpdateKeyFrameControls(List<KeyFrame> frames)
+        public void UpdateKeyFrameControls(List<KeyFrame> frames, float? time)
         {
             keyFrames = frames;
+
+            var match = keyFrames.FirstOrDefault(x => Mathf.Approximately(x.time, time ?? 0));
+            currentKeyframeName = match != null ? $"Keyframe {keyFrames.IndexOf(match) + 1}" : string.Empty;
         }
         
         public void UpdateTextFields(Transform cameraTransform, float? time)


### PR DESCRIPTION
- Adds a section up top with four buttons to navigate keyframes:
  - `<<` - goes to first keyframe
  - `<` - works exactly like hitting left dpad
  - `>` - works exactly like hitting right dpad
  - `>>` - goes to first keyframe
- If the current time is on an existing keyframe, displays `Keyframe #` above the keyframe nav buttons.