### PR TITLE
Allowing Time Edit and Adding Time Info

### DIFF
--- a/XLPrecisionKeyframes/Keyframes/KeyframeInfo.cs
+++ b/XLPrecisionKeyframes/Keyframes/KeyframeInfo.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using ReplayEditor;
+﻿using ReplayEditor;
+using System;
 using UnityEngine;
 
 namespace XLPrecisionKeyframes.Keyframes
@@ -9,20 +9,20 @@ namespace XLPrecisionKeyframes.Keyframes
     {
         public PositionInfo position;
         public RotationInfo rotation;
-        public float time;
+        public TimeInfo time;
 
         public KeyframeInfo()
         {
             position = new PositionInfo();
             rotation = new RotationInfo();
-            time = 0;
+            time = new TimeInfo();
         }
 
         public KeyframeInfo(Vector3 pos, Quaternion rot)
         {
             position = new PositionInfo(pos);
             rotation = new RotationInfo(rot);
-            time = 0;
+            time = new TimeInfo();
         }
 
         public KeyframeInfo(Transform transform) : this(transform.position, transform.rotation)
@@ -32,7 +32,7 @@ namespace XLPrecisionKeyframes.Keyframes
 
         public KeyframeInfo(KeyFrame keyframe) : this(keyframe.position, keyframe.rotation)
         {
-            time = keyframe.time;
+            time = new TimeInfo(keyframe.time);
         }
     }
 }

--- a/XLPrecisionKeyframes/Keyframes/TimeInfo.cs
+++ b/XLPrecisionKeyframes/Keyframes/TimeInfo.cs
@@ -1,0 +1,39 @@
+﻿using ReplayEditor;
+using System;
+
+namespace XLPrecisionKeyframes.Keyframes
+{
+    [Serializable]
+    public class TimeInfo
+    {
+        public float time;
+        public float timeFromEnd;
+        public float timeFromPrevKeyframe;
+        public float timeFromNextKeyframe;
+
+        public TimeInfo() : this(0)
+        {
+            
+        }
+
+        public TimeInfo(float time)
+        {
+            this.time = time;
+        }
+
+        public void Update(float newTime)
+        {
+            time = newTime;
+
+            var clipEndTime = ReplayEditorController.Instance.playbackController.ClipEndTime;
+
+            timeFromEnd = clipEndTime - time;
+
+            var prevKeyFrame = ReplayEditorController.Instance.cameraController.FindNextKeyFrame(time, true);
+            timeFromPrevKeyframe = time - (prevKeyFrame?.time ?? 0);
+
+            var nextKeyFrame = ReplayEditorController.Instance.cameraController.FindNextKeyFrame(time, false);
+            timeFromNextKeyframe = (nextKeyFrame?.time ?? clipEndTime) - time;
+        }
+    }
+}

--- a/XLPrecisionKeyframes/UserInterface/EditBaseUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditBaseUI.cs
@@ -1,9 +1,30 @@
-﻿using UnityEngine;
+﻿using System.Linq;
+using UnityEngine;
 
 namespace XLPrecisionKeyframes.UserInterface
 {
     public class EditBaseUI : MonoBehaviour
     {
+        private bool HasKeyframes => UserInterface.keyFrames != null && UserInterface.keyFrames.Any();
+        private bool HasKeyframeName => !string.IsNullOrEmpty(UserInterface.currentKeyframeName);
+
+        protected float GetYPos(float originalYPos)
+        {
+            var yPos = originalYPos;
+
+            switch (HasKeyframes)
+            {
+                case true when HasKeyframeName:
+                    yPos += 45;
+                    break;
+                case true:
+                    yPos += 25;
+                    break;
+            }
+
+            return yPos;
+        }
+
         protected string CreateFloatField(string label, string value)
         {
             GUILayout.BeginHorizontal();

--- a/XLPrecisionKeyframes/UserInterface/EditPositionUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditPositionUI.cs
@@ -26,7 +26,7 @@ namespace XLPrecisionKeyframes.UserInterface
                 stretchWidth = false
             };
 
-            GUILayout.Window(824, new Rect(295, 80, 200, 50), DrawWindow, "Edit Position", style);
+            GUILayout.Window(824, new Rect(295, GetYPos(85), 200, 50), DrawWindow, "Edit Position", style);
         }
 
         private void DrawWindow(int windowID)

--- a/XLPrecisionKeyframes/UserInterface/EditPositionUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditPositionUI.cs
@@ -26,7 +26,7 @@ namespace XLPrecisionKeyframes.UserInterface
                 stretchWidth = false
             };
 
-            GUILayout.Window(824, new Rect(245, 80, 200, 50), DrawWindow, "Edit Position", style);
+            GUILayout.Window(824, new Rect(295, 80, 200, 50), DrawWindow, "Edit Position", style);
         }
 
         private void DrawWindow(int windowID)

--- a/XLPrecisionKeyframes/UserInterface/EditRotationUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditRotationUI.cs
@@ -26,7 +26,7 @@ namespace XLPrecisionKeyframes.UserInterface
                 stretchWidth = false
             };
 
-            GUILayout.Window(825, new Rect(245, 170, 200, 50), DrawWindow, "Edit Rotation", style);
+            GUILayout.Window(825, new Rect(295, 170, 200, 50), DrawWindow, "Edit Rotation", style);
         }
 
         private void DrawWindow(int windowID)

--- a/XLPrecisionKeyframes/UserInterface/EditRotationUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditRotationUI.cs
@@ -26,7 +26,7 @@ namespace XLPrecisionKeyframes.UserInterface
                 stretchWidth = false
             };
 
-            GUILayout.Window(825, new Rect(295, 170, 200, 50), DrawWindow, "Edit Rotation", style);
+            GUILayout.Window(825, new Rect(295, GetYPos(170), 200, 50), DrawWindow, "Edit Rotation", style);
         }
 
         private void DrawWindow(int windowID)

--- a/XLPrecisionKeyframes/UserInterface/EditTimeUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditTimeUI.cs
@@ -28,7 +28,7 @@ namespace XLPrecisionKeyframes.UserInterface
                 stretchWidth = false
             };
 
-            GUILayout.Window(824, new Rect(245, 80, 200, 50), DrawWindow, "Edit Time", style);
+            GUILayout.Window(824, new Rect(295, GetYPos(280), 200, 50), DrawWindow, "Edit Time", style);
         }
 
         private void DrawWindow(int windowID)
@@ -60,7 +60,9 @@ namespace XLPrecisionKeyframes.UserInterface
 
         private void UpdateTimelinePosition()
         {
-            ReplayEditorController.Instance.SetPlaybackTime(time);
+            if (!float.TryParse(timeString, out var newTime)) return;
+
+            ReplayEditorController.Instance.SetPlaybackTime(newTime);
         }
 
         private void CreateTimeControls()

--- a/XLPrecisionKeyframes/UserInterface/EditTimeUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditTimeUI.cs
@@ -1,0 +1,75 @@
+﻿using ReplayEditor;
+using UnityEngine;
+
+namespace XLPrecisionKeyframes.UserInterface
+{
+    public class EditTimeUI : EditBaseUI
+    {
+        public float time;
+        public float originalTime;
+
+        private string timeString;
+
+        public void SetTime(float time)
+        {
+            this.time = time;
+            this.timeString = time.ToString("F8");
+            this.originalTime = time;
+        }
+
+        private void OnGUI()
+        {
+            GUI.backgroundColor = Color.black;
+
+            var style = new GUIStyle(GUI.skin.window)
+            {
+                contentOffset = new Vector2(0, -20),
+                stretchHeight = false,
+                stretchWidth = false
+            };
+
+            GUILayout.Window(824, new Rect(245, 80, 200, 50), DrawWindow, "Edit Time", style);
+        }
+
+        private void DrawWindow(int windowID)
+        {
+            GUI.DragWindow(new Rect(0.0f, 0.0f, 10000f, 20f));
+            GUI.backgroundColor = Color.black;
+
+            GUILayout.BeginVertical();
+
+            CreateTimeControls();
+
+            GUILayout.BeginHorizontal();
+
+            if (GUILayout.Button("Save"))
+            {
+                UpdateTimelinePosition();
+                gameObject.SetActive(false);
+            }
+
+            if (GUILayout.Button("Cancel"))
+            {
+                gameObject.SetActive(false);
+            }
+
+            GUILayout.EndHorizontal();
+
+            GUILayout.EndVertical();
+        }
+
+        private void UpdateTimelinePosition()
+        {
+            ReplayEditorController.Instance.SetPlaybackTime(time);
+        }
+
+        private void CreateTimeControls()
+        {
+            GUILayout.BeginVertical();
+
+            timeString = CreateFloatField("Time", timeString);
+
+            GUILayout.EndVertical();
+        }
+    }
+}

--- a/XLPrecisionKeyframes/UserInterface/UserInterface.cs
+++ b/XLPrecisionKeyframes/UserInterface/UserInterface.cs
@@ -20,14 +20,18 @@ namespace XLPrecisionKeyframes.UserInterface
         /// <summary>
         /// A list of keyframes that are currently in editor.  Currently used for the keyframe controls, knowing whether to hide them or how to cycle through them.
         /// </summary>
-        private static List<KeyFrame> keyFrames = new List<KeyFrame>();
+        public static List<KeyFrame> keyFrames = new List<KeyFrame>();
 
-        private static string currentKeyframeName = "";
+        public static string currentKeyframeName = "";
 
         private GameObject EditPositionGameObject;
         private EditPositionUI EditPositionUI;
+
         private GameObject EditRotationGameObject;
         private EditRotationUI EditRotationUI;
+
+        private GameObject EditTimeGameObject;
+        private EditTimeUI EditTimeUI;
 
         private void OnEnable()
         {
@@ -41,6 +45,11 @@ namespace XLPrecisionKeyframes.UserInterface
             EditRotationUI = EditRotationGameObject.AddComponent<EditRotationUI>();
             DontDestroyOnLoad(EditRotationGameObject);
 
+            EditTimeGameObject = new GameObject();
+            EditTimeGameObject.SetActive(false);
+            EditTimeUI = EditTimeGameObject.AddComponent<EditTimeUI>();
+            DontDestroyOnLoad(EditTimeGameObject);
+
             Cursor.visible = true;
             Cursor.lockState = CursorLockMode.None;
         }
@@ -49,6 +58,7 @@ namespace XLPrecisionKeyframes.UserInterface
         {
             DestroyImmediate(EditPositionGameObject);
             DestroyImmediate(EditRotationGameObject);
+            DestroyImmediate(EditTimeGameObject);
 
             Cursor.visible = false;
             Cursor.lockState = CursorLockMode.Locked;
@@ -65,7 +75,7 @@ namespace XLPrecisionKeyframes.UserInterface
                 stretchWidth = false
             };
 
-            GUILayout.Window(823, new Rect(40, 40, 200, 50), DrawWindow, "XL Precision Keyframes", style);
+            GUILayout.Window(823, new Rect(40, 40, 250, 50), DrawWindow, "XL Precision Keyframes", style);
         }
 
         private void DrawWindow(int windowID)
@@ -211,7 +221,28 @@ namespace XLPrecisionKeyframes.UserInterface
         /// </summary>
         private void CreateTimeControls()
         {
-            CreateFloatField("Time", displayed.time.ToString("F8"), false);
+            GUILayout.BeginVertical();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("<b>Time</b>");
+
+            if (GUILayout.Button("Edit"))
+            {
+                EditTimeGameObject.SetActive(true);
+                EditTimeUI.SetTime(displayed.time.time);
+            }
+            GUILayout.EndHorizontal();
+
+            CreateFloatField("Time", displayed.time.time.ToString("F8"));
+            CreateFloatField("From End", displayed.time.timeFromEnd.ToString("F8"));
+
+            if (keyFrames != null && keyFrames.Any())
+            {
+                CreateFloatField("To Prev Keyframe", displayed.time.timeFromPrevKeyframe.ToString("F8"));
+                CreateFloatField("To Next Keyframe", displayed.time.timeFromNextKeyframe.ToString("F8"));
+            }
+
+            GUILayout.EndVertical();
         }
         
         private void CreateFloatField(string label, string value, bool isIndented = true)
@@ -244,7 +275,7 @@ namespace XLPrecisionKeyframes.UserInterface
 
             displayed.position.Update(cameraTransform.position);
             displayed.rotation.Update(cameraTransform.rotation);
-            displayed.time = time ?? 0;
+            displayed.time.Update(time ?? 0);
         }
     }
 }

--- a/XLPrecisionKeyframes/XLPrecisionKeyframes.csproj
+++ b/XLPrecisionKeyframes/XLPrecisionKeyframes.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Keyframes\KeyframeInfo.cs" />
     <Compile Include="Keyframes\PositionInfo.cs" />
     <Compile Include="Keyframes\RotationInfo.cs" />
+    <Compile Include="Keyframes\TimeInfo.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="Patches\ReplayStatePatch.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/XLPrecisionKeyframes/XLPrecisionKeyframes.csproj
+++ b/XLPrecisionKeyframes/XLPrecisionKeyframes.csproj
@@ -75,6 +75,7 @@
     <Compile Include="UserInterface\EditBaseUI.cs" />
     <Compile Include="UserInterface\EditPositionUI.cs" />
     <Compile Include="UserInterface\EditRotationUI.cs" />
+    <Compile Include="UserInterface\EditTimeUI.cs" />
     <Compile Include="UserInterface\UserInterface.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Allowing the user to edit time
- Adding up to three new display fields for various time information:
  - time to end of timeline
  - time to next keyframe (if keyframes are present)
  - time to previous keyframe (if keyframes are present)