### PR TITLE
Fixing Bug Where Times Would Be 0 Using `Copy All`

### DIFF
--- a/XLPrecisionKeyframes/Keyframes/TimeInfo.cs
+++ b/XLPrecisionKeyframes/Keyframes/TimeInfo.cs
@@ -29,10 +29,12 @@ namespace XLPrecisionKeyframes.Keyframes
 
             timeFromEnd = clipEndTime - time;
 
-            var prevKeyFrame = ReplayEditorController.Instance.cameraController.FindNextKeyFrame(time, true);
+            var camController = ReplayEditorController.Instance.cameraController;
+
+            var prevKeyFrame = camController.FindNextKeyFrame(time, true);
             timeFromPrevKeyframe = time - (prevKeyFrame?.time ?? 0);
 
-            var nextKeyFrame = ReplayEditorController.Instance.cameraController.FindNextKeyFrame(time, false);
+            var nextKeyFrame = camController.FindNextKeyFrame(time, false);
             timeFromNextKeyframe = (nextKeyFrame?.time ?? clipEndTime) - time;
         }
     }

--- a/XLPrecisionKeyframes/Keyframes/TimeInfo.cs
+++ b/XLPrecisionKeyframes/Keyframes/TimeInfo.cs
@@ -18,7 +18,7 @@ namespace XLPrecisionKeyframes.Keyframes
 
         public TimeInfo(float time)
         {
-            this.time = time;
+            Update(time);
         }
 
         public void Update(float newTime)


### PR DESCRIPTION
- Fixed an issue where `time.timeFromEnd`, `time.timeFromPrevKeyframe`, and `time.timeFromNextKeyframe` would all be `0` when using the `Copy All` button.