### PR TITLE
Keyframe Pasting Support

### DIFF
--- a/XLPrecisionKeyframes/UserInterface/EditBaseUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditBaseUI.cs
@@ -107,7 +107,7 @@ namespace XLPrecisionKeyframes.UserInterface
 
         private void CloseWindow()
         {
-            gameObject.SetActive(false);
+            gameObject?.SetActive(false);
         }
 
         public virtual void SetValue(PositionInfo position)

--- a/XLPrecisionKeyframes/UserInterface/EditBaseUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditBaseUI.cs
@@ -10,11 +10,14 @@ namespace XLPrecisionKeyframes.UserInterface
         private bool HasKeyframeName => !string.IsNullOrEmpty(UserInterface.currentKeyframeName);
 
         protected float StartingYPos;
+        protected bool IgnoreYPosChanges;
         protected string WindowLabel;
 
         protected float GetYPos(float originalYPos)
         {
             var yPos = originalYPos;
+
+            if (IgnoreYPosChanges) return yPos;
 
             switch (HasKeyframes)
             {
@@ -92,7 +95,7 @@ namespace XLPrecisionKeyframes.UserInterface
             GUILayout.EndHorizontal();
         }
 
-        protected virtual void Save()
+        public virtual void Save()
         {
             CloseWindow();
         }

--- a/XLPrecisionKeyframes/UserInterface/EditBaseUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditBaseUI.cs
@@ -81,18 +81,23 @@ namespace XLPrecisionKeyframes.UserInterface
         protected virtual void CreateSaveAndCancelButtons()
         {
             GUILayout.BeginHorizontal();
-
-            if (GUILayout.Button("Save"))
-            {
-                Save();
-            }
-
-            if (GUILayout.Button("Cancel"))
-            {
-                Cancel();
-            }
-
+            CreateSaveButton();
+            CreateCancelButton();
             GUILayout.EndHorizontal();
+        }
+
+        protected virtual void CreateSaveButton()
+        {
+            if (!GUILayout.Button("Save")) return;
+
+            Save();
+        }
+
+        protected virtual void CreateCancelButton()
+        {
+            if (!GUILayout.Button("Cancel")) return;
+                
+            Cancel();
         }
 
         public virtual void Save()

--- a/XLPrecisionKeyframes/UserInterface/EditFieldOfViewUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditFieldOfViewUI.cs
@@ -26,7 +26,7 @@ namespace XLPrecisionKeyframes.UserInterface
             base.OnGUI();
         }
 
-        protected override void Save()
+        public override void Save()
         {
             if (!float.TryParse(fovString, out var newFov)) return;
 

--- a/XLPrecisionKeyframes/UserInterface/EditPositionUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditPositionUI.cs
@@ -23,7 +23,7 @@ namespace XLPrecisionKeyframes.UserInterface
             base.OnGUI();
         }
 
-        protected override void Save()
+        public override void Save()
         {
             ReplayEditorController.Instance.cameraController.ReplayCamera.transform.position = position.ConvertToVector3();
             base.Save();

--- a/XLPrecisionKeyframes/UserInterface/EditRotationUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditRotationUI.cs
@@ -23,7 +23,7 @@ namespace XLPrecisionKeyframes.UserInterface
             base.OnGUI();
         }
 
-        protected override void Save()
+        public override void Save()
         {
             ReplayEditorController.Instance.cameraController.ReplayCamera.transform.rotation = rotation.ConvertToQuaternion();
             base.Save();

--- a/XLPrecisionKeyframes/UserInterface/EditTimeUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/EditTimeUI.cs
@@ -26,7 +26,7 @@ namespace XLPrecisionKeyframes.UserInterface
             base.OnGUI();
         }
 
-        protected override void Save()
+        public override void Save()
         {
             if (!float.TryParse(timeString, out var newTime)) return;
 

--- a/XLPrecisionKeyframes/UserInterface/PasteUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/PasteUI.cs
@@ -41,6 +41,7 @@ namespace XLPrecisionKeyframes.UserInterface
             }
             catch (Exception ex)
             {
+                parseFailed = true;
                 UnityModManager.Logger.Log("XLPK: Exception caught deserializing JSON: " + pastedJson + ex);
                 return;
             }
@@ -53,6 +54,12 @@ namespace XLPrecisionKeyframes.UserInterface
             parseFailed = false;
 
             base.Save();
+        }
+
+        protected override void Cancel()
+        {
+            pastedJson = string.Empty;
+            base.Cancel();
         }
 
         protected override void CreateSaveButton()

--- a/XLPrecisionKeyframes/UserInterface/PasteUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/PasteUI.cs
@@ -67,8 +67,8 @@ namespace XLPrecisionKeyframes.UserInterface
             if (string.IsNullOrEmpty(pastedJson)) return;
 
             var buttonStyle = new GUIStyle(GUI.skin.button);
-            buttonStyle.normal.textColor = parseFailed ? Color.red : Color.white;
-
+            buttonStyle.normal.textColor = buttonStyle.hover.textColor = parseFailed ? Color.red : Color.white;
+            
             if (!GUILayout.Button("Save", buttonStyle)) return;
 
             Save();

--- a/XLPrecisionKeyframes/UserInterface/PasteUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/PasteUI.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using Newtonsoft.Json;
+using UnityEngine;
+using UnityModManagerNet;
+using XLPrecisionKeyframes.Keyframes;
+
+namespace XLPrecisionKeyframes.UserInterface
+{
+    public class PasteUI : EditBaseUI
+    {
+        private string pastedJson;
+
+        private bool parseFailed;
+
+        protected override void OnGUI()
+        {
+            StartingYPos = 40;
+            IgnoreYPosChanges = true;
+            WindowLabel = "Paste Keyframe JSON";
+
+            base.OnGUI();
+        }
+
+        public override void Save()
+        {
+            if (string.IsNullOrEmpty(pastedJson)) return;
+
+            SanitizeDiscordTags();
+
+            KeyframeInfo keyFrameInfo = null;
+
+            try
+            {
+                keyFrameInfo = JsonConvert.DeserializeObject<KeyframeInfo>(pastedJson);
+
+                if (keyFrameInfo == null)
+                {
+                    parseFailed = true;
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                UnityModManager.Logger.Log("XLPK: Exception caught deserializing JSON: " + pastedJson + ex);
+                return;
+            }
+
+            SetValue(UserInterface.Instance.EditPositionUI, keyFrameInfo);
+            SetValue(UserInterface.Instance.EditRotationUI, keyFrameInfo);
+            SetValue(UserInterface.Instance.EditFovUI, keyFrameInfo);
+
+            pastedJson = string.Empty;
+            parseFailed = false;
+
+            base.Save();
+        }
+
+        protected override void CreateSaveButton()
+        {
+            if (string.IsNullOrEmpty(pastedJson)) return;
+
+            var buttonStyle = new GUIStyle(GUI.skin.button);
+            buttonStyle.normal.textColor = parseFailed ? Color.red : Color.white;
+
+            if (!GUILayout.Button("Save", buttonStyle)) return;
+
+            Save();
+        }
+
+        private void SetValue<T>(UserInterfacePopup<T> ui, KeyframeInfo keyframe) where T : EditBaseUI
+        {
+            if (ui == null)
+            {
+                ui = new UserInterfacePopup<T>();
+            }
+
+            switch (ui)
+            {
+                case UserInterfacePopup<EditPositionUI> pos:
+                    ui.SetValue(keyframe.position);
+                    break;
+                case UserInterfacePopup<EditRotationUI> rot:
+                    ui.SetValue(keyframe.rotation);
+                    break;
+                case UserInterfacePopup<EditFieldOfViewUI> fov:
+                    ui.SetValue(keyframe.fov);
+                    break;
+                default: break;
+            }
+
+            ui.Save();
+            ui.Destroy();
+        }
+
+        private void SanitizeDiscordTags()
+        {
+            if (pastedJson.StartsWith("```json"))
+            {
+                pastedJson = pastedJson.Remove(0, 7);
+            }
+            else if (pastedJson.StartsWith("```"))
+            {
+                pastedJson = pastedJson.Remove(0, 3);
+            }
+
+            if (pastedJson.EndsWith("```"))
+            {
+                pastedJson = pastedJson.Remove(pastedJson.Length - 3, 3);
+            }
+
+            pastedJson = pastedJson.Trim();
+        }
+
+        protected override void CreateControls()
+        {
+            GUILayout.BeginVertical();
+            pastedJson = GUILayout.TextArea(pastedJson, GUILayout.ExpandHeight(true), GUILayout.MinHeight(200), GUILayout.MinHeight(400));
+            GUILayout.EndVertical();
+        }
+    }
+}

--- a/XLPrecisionKeyframes/UserInterface/UserInterface.cs
+++ b/XLPrecisionKeyframes/UserInterface/UserInterface.cs
@@ -24,11 +24,11 @@ namespace XLPrecisionKeyframes.UserInterface
 
         public static string currentKeyframeName = "";
 
-        private UserInterfacePopup<PasteUI> PasteUI;
-        public UserInterfacePopup<EditPositionUI> EditPositionUI;
-        public UserInterfacePopup<EditRotationUI> EditRotationUI;
-        private UserInterfacePopup<EditTimeUI> EditTimeUI;
-        public UserInterfacePopup<EditFieldOfViewUI> EditFovUI;
+        public UserInterfacePopup<PasteUI> PasteUI { get; set; }
+        public UserInterfacePopup<EditPositionUI> EditPositionUI { get; set; }
+        public UserInterfacePopup<EditRotationUI> EditRotationUI { get; set; }
+        public UserInterfacePopup<EditTimeUI> EditTimeUI { get; set; }
+        public UserInterfacePopup<EditFieldOfViewUI> EditFovUI { get; set; }
 
         private void OnEnable()
         {

--- a/XLPrecisionKeyframes/UserInterface/UserInterface.cs
+++ b/XLPrecisionKeyframes/UserInterface/UserInterface.cs
@@ -24,13 +24,15 @@ namespace XLPrecisionKeyframes.UserInterface
 
         public static string currentKeyframeName = "";
 
-        private UserInterfacePopup<EditPositionUI> EditPositionUI;
-        private UserInterfacePopup<EditRotationUI> EditRotationUI;
+        private UserInterfacePopup<PasteUI> PasteUI;
+        public UserInterfacePopup<EditPositionUI> EditPositionUI;
+        public UserInterfacePopup<EditRotationUI> EditRotationUI;
         private UserInterfacePopup<EditTimeUI> EditTimeUI;
-        private UserInterfacePopup<EditFieldOfViewUI> EditFovUI;
+        public UserInterfacePopup<EditFieldOfViewUI> EditFovUI;
 
         private void OnEnable()
         {
+            PasteUI = new UserInterfacePopup<PasteUI>();
             EditPositionUI = new UserInterfacePopup<EditPositionUI>();
             EditRotationUI = new UserInterfacePopup<EditRotationUI>();
             EditTimeUI = new UserInterfacePopup<EditTimeUI>();
@@ -42,6 +44,7 @@ namespace XLPrecisionKeyframes.UserInterface
 
         private void OnDisable()
         {
+            PasteUI.Destroy();
             EditPositionUI.Destroy();
             EditRotationUI.Destroy();
             EditTimeUI.Destroy();
@@ -129,6 +132,8 @@ namespace XLPrecisionKeyframes.UserInterface
 
         private void CreateCopyPasteControls()
         {
+            GUILayout.BeginVertical();
+
             GUILayout.BeginHorizontal();
 
             if (GUILayout.Button("Copy"))
@@ -143,7 +148,14 @@ namespace XLPrecisionKeyframes.UserInterface
                 AddToClipboard(frames);
             }
 
+            if (GUILayout.Button("Paste JSON"))
+            {
+                PasteUI.Show();
+            }
+
             GUILayout.EndHorizontal();
+
+            GUILayout.EndVertical();
         }
 
         private void AddToClipboard(object o)

--- a/XLPrecisionKeyframes/UserInterface/UserInterfacePopup.cs
+++ b/XLPrecisionKeyframes/UserInterface/UserInterfacePopup.cs
@@ -21,7 +21,35 @@ namespace XLPrecisionKeyframes.UserInterface
             Object.DestroyImmediate(gameObject);
         }
 
-        private void Show()
+        public void Save()
+        {
+            ui.Save();
+        }
+
+        #region SetValue
+        public void SetValue(PositionInfo position)
+        {
+            ui.SetValue(position);
+        }
+
+        public void SetValue(RotationInfo rotation)
+        {
+            ui.SetValue(rotation);
+        }
+
+        public void SetValue(TimeInfo time)
+        {
+            ui.SetValue(time);
+        }
+
+        public void SetValue(FieldOfViewInfo fov)
+        {
+            ui.SetValue(fov);
+        }
+        #endregion
+
+        #region Show()
+        public void Show()
         {
             gameObject.SetActive(true);
         }
@@ -29,25 +57,26 @@ namespace XLPrecisionKeyframes.UserInterface
         public void Show(PositionInfo position)
         {
             Show();
-            ui.SetValue(position);
+            SetValue(position);
         }
 
         public void Show(RotationInfo rotation)
         {
             Show();
-            ui.SetValue(rotation);
+            SetValue(rotation);
         }
 
         public void Show(TimeInfo time)
         {
             Show();
-            ui.SetValue(time);
+            SetValue(time);
         }
 
         public void Show(FieldOfViewInfo fov)
         {
             Show();
-            ui.SetValue(fov);
+            SetValue(fov);
         }
+        #endregion
     }
 }

--- a/XLPrecisionKeyframes/XLPrecisionKeyframes.csproj
+++ b/XLPrecisionKeyframes/XLPrecisionKeyframes.csproj
@@ -85,6 +85,7 @@
     <Compile Include="UserInterface\EditRotationUI.cs" />
     <Compile Include="UserInterface\EditTimeUI.cs" />
     <Compile Include="UserInterface\EditFieldOfViewUI.cs" />
+    <Compile Include="UserInterface\PasteUI.cs" />
     <Compile Include="UserInterface\UserInterface.cs" />
     <Compile Include="UserInterface\UserInterfacePopup.cs" />
   </ItemGroup>


### PR DESCRIPTION
- Added new button `Paste JSON` that allows you to paste in an entire keyframe JSON.
  - If it begins with discord code blocks, we'll strip them and strip any whitespace.
  - If we can't parse or deserialize the JSON, the Save button will turn red.
  - When we can deserialize the JSON properly, will update position, rotation, and FOV values if present.  Will ignore any time values as these are least likely to not maintain consistency across replays. 