### PR TITLE
Adding Settings to Position Windows

### DIFF
--- a/XLPrecisionKeyframes/Main.cs
+++ b/XLPrecisionKeyframes/Main.cs
@@ -26,6 +26,8 @@ namespace XLPrecisionKeyframes
             Object.DontDestroyOnLoad(UserInterfaceGameObject);
 
             modEntry.OnToggle = OnToggle;
+            modEntry.OnGUI = Settings.Instance.OnSettingsGUI;
+            modEntry.OnSaveGUI = Settings.Instance.Save;
 #if DEBUG
             modEntry.OnUnload = Unload;
 #endif

--- a/XLPrecisionKeyframes/Settings.cs
+++ b/XLPrecisionKeyframes/Settings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine;
 using UnityModManagerNet;
 
 namespace XLPrecisionKeyframes
@@ -8,6 +9,9 @@ namespace XLPrecisionKeyframes
     {
         public static Settings Instance { get; set; }
         public static UnityModManager.ModEntry ModEntry;
+
+        public float WindowXPos { get; set; } = 40;
+        public float WindowYPos { get; set; } = 40;
 
         public Settings() : base()
         {
@@ -22,6 +26,36 @@ namespace XLPrecisionKeyframes
         public void Save()
         {
             Save(ModEntry);
+        }
+
+        public void OnSettingsGUI(UnityModManager.ModEntry modEntry)
+        {
+            GUILayout.BeginVertical();
+
+            GUILayout.Label("Window Position:");
+
+            var rightAligned = new GUIStyle(GUI.skin.textField)
+            {
+                alignment = TextAnchor.MiddleRight
+            };
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("X:");
+            if (float.TryParse(GUILayout.TextField(WindowXPos.ToString(), rightAligned), out float xPos))
+            {
+                WindowXPos = xPos;
+            }
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Y:");
+            if (float.TryParse(GUILayout.TextField(WindowYPos.ToString(), rightAligned), out float yPos))
+            {
+                WindowYPos = yPos;
+            }
+            GUILayout.EndHorizontal();
+
+            GUILayout.EndVertical();
         }
     }
 }

--- a/XLPrecisionKeyframes/UserInterface/UserInterface.cs
+++ b/XLPrecisionKeyframes/UserInterface/UserInterface.cs
@@ -62,7 +62,7 @@ namespace XLPrecisionKeyframes.UserInterface
                 stretchWidth = false
             };
 
-            GUILayout.Window(823, new Rect(40, 40, 250, 50), DrawWindow, "XL Precision Keyframes", style);
+            GUILayout.Window(823, new Rect(Settings.Instance.WindowXPos, Settings.Instance.WindowYPos, 250, 50), DrawWindow, "XL Precision Keyframes", style);
         }
 
         private void DrawWindow(int windowID)


### PR DESCRIPTION
- Adding simple UMM settings to position the window.  This allows users to set custom positions for their menus to avoid Reshade or XLGraphics overlaying the menu.