### PR TITLE
Fixing Submenu Positioning

### DIFF
--- a/XLPrecisionKeyframes/UserInterface/Popups/EditBaseUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/Popups/EditBaseUI.cs
@@ -59,7 +59,8 @@ namespace XLPrecisionKeyframes.UserInterface.Popups
                 stretchWidth = false
             };
 
-            GUILayout.Window(824, new Rect(295, GetYPos(StartingYPos), 200, 50), DrawWindow, WindowLabel, style);
+            var xPos = Settings.Instance.WindowXPos + 255;
+            GUILayout.Window(824, new Rect(xPos, GetYPos(StartingYPos), 200, 50), DrawWindow, WindowLabel, style);
         }
 
         protected virtual void DrawWindow(int windowID)

--- a/XLPrecisionKeyframes/UserInterface/Popups/EditBaseUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/Popups/EditBaseUI.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using XLPrecisionKeyframes.Keyframes;
 
-namespace XLPrecisionKeyframes.UserInterface
+namespace XLPrecisionKeyframes.UserInterface.Popups
 {
     public class EditBaseUI : MonoBehaviour
     {

--- a/XLPrecisionKeyframes/UserInterface/Popups/EditFieldOfViewUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/Popups/EditFieldOfViewUI.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using XLPrecisionKeyframes.Keyframes;
 
-namespace XLPrecisionKeyframes.UserInterface
+namespace XLPrecisionKeyframes.UserInterface.Popups
 {
     public class EditFieldOfViewUI : EditBaseUI
     {

--- a/XLPrecisionKeyframes/UserInterface/Popups/EditPositionUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/Popups/EditPositionUI.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using XLPrecisionKeyframes.Keyframes;
 
-namespace XLPrecisionKeyframes.UserInterface
+namespace XLPrecisionKeyframes.UserInterface.Popups
 {
     public class EditPositionUI : EditBaseUI
     {

--- a/XLPrecisionKeyframes/UserInterface/Popups/EditRotationUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/Popups/EditRotationUI.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using XLPrecisionKeyframes.Keyframes;
 
-namespace XLPrecisionKeyframes.UserInterface
+namespace XLPrecisionKeyframes.UserInterface.Popups
 {
     public class EditRotationUI : EditBaseUI
     {

--- a/XLPrecisionKeyframes/UserInterface/Popups/EditTimeUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/Popups/EditTimeUI.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using XLPrecisionKeyframes.Keyframes;
 
-namespace XLPrecisionKeyframes.UserInterface
+namespace XLPrecisionKeyframes.UserInterface.Popups
 {
     public class EditTimeUI : EditBaseUI
     {

--- a/XLPrecisionKeyframes/UserInterface/Popups/PasteUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/Popups/PasteUI.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 using UnityModManagerNet;
 using XLPrecisionKeyframes.Keyframes;
 
-namespace XLPrecisionKeyframes.UserInterface
+namespace XLPrecisionKeyframes.UserInterface.Popups
 {
     public class PasteUI : EditBaseUI
     {

--- a/XLPrecisionKeyframes/UserInterface/Popups/UserInterfacePopup.cs
+++ b/XLPrecisionKeyframes/UserInterface/Popups/UserInterfacePopup.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEngine;
 using XLPrecisionKeyframes.Keyframes;
 
-namespace XLPrecisionKeyframes.UserInterface
+namespace XLPrecisionKeyframes.UserInterface.Popups
 {
     public class UserInterfacePopup<T> where T : EditBaseUI
     {

--- a/XLPrecisionKeyframes/UserInterface/UserInterface.cs
+++ b/XLPrecisionKeyframes/UserInterface/UserInterface.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using XLPrecisionKeyframes.Keyframes;
+using XLPrecisionKeyframes.UserInterface.Popups;
 
 namespace XLPrecisionKeyframes.UserInterface
 {

--- a/XLPrecisionKeyframes/XLPrecisionKeyframes.csproj
+++ b/XLPrecisionKeyframes/XLPrecisionKeyframes.csproj
@@ -80,14 +80,14 @@
     <Compile Include="Patches\ReplayStatePatch.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.cs" />
-    <Compile Include="UserInterface\EditBaseUI.cs" />
-    <Compile Include="UserInterface\EditPositionUI.cs" />
-    <Compile Include="UserInterface\EditRotationUI.cs" />
-    <Compile Include="UserInterface\EditTimeUI.cs" />
-    <Compile Include="UserInterface\EditFieldOfViewUI.cs" />
-    <Compile Include="UserInterface\PasteUI.cs" />
+    <Compile Include="UserInterface\Popups\EditBaseUI.cs" />
+    <Compile Include="UserInterface\Popups\EditPositionUI.cs" />
+    <Compile Include="UserInterface\Popups\EditRotationUI.cs" />
+    <Compile Include="UserInterface\Popups\EditTimeUI.cs" />
+    <Compile Include="UserInterface\Popups\EditFieldOfViewUI.cs" />
+    <Compile Include="UserInterface\Popups\PasteUI.cs" />
     <Compile Include="UserInterface\UserInterface.cs" />
-    <Compile Include="UserInterface\UserInterfacePopup.cs" />
+    <Compile Include="UserInterface\Popups\UserInterfacePopup.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.json">


### PR DESCRIPTION
- When modifying the Window X Position, all of the sub menus (edit position, edit rotation, edit time, edit FOV, paste JSON) would not respect this position.
- Updated all of these sub menus to respect that mod setting.