### PR TITLE
Fixing Keyframe Offset Bug

### DIFF
--- a/XLPrecisionKeyframes/UserInterface/Popups/OffsetKeyframesUI.cs
+++ b/XLPrecisionKeyframes/UserInterface/Popups/OffsetKeyframesUI.cs
@@ -22,11 +22,7 @@ namespace XLPrecisionKeyframes.UserInterface.Popups
             if (!float.TryParse(offsetString, out var newOffset)) return;
 
             var camController = ReplayEditorController.Instance.cameraController;
-            foreach (var keyframe in camController.keyFrames)
-            {
-                keyframe.time += newOffset;
-            }
-
+            camController.MoveKeyframesBy(newOffset);
             camController.keyframeUI.UpdateKeyframes(camController.keyFrames);
 
             base.Save();


### PR DESCRIPTION
- Offsetting keyframes would update the keyframes and UI, but the user would actually have to exit replay and re-enter for them to "hold".
- Calling ReplayEditorController's `MoveKeyframesBy` method, does the same thing I was doing (appending time to existing time), but also refreshes the camera curve, which was the step we were missing.